### PR TITLE
Add interactive financial dashboard with coffee imagery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# camera
+# Camera
+
+This project includes a simple financial dashboard. Open `index.html` in your browser to explore interactive charts and an illustration of green coffee in burlap bags.

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,62 @@
+const labels = ["Jan", "Feb", "Mar", "Apr", "May", "Jun"];
+const revenueData = [12000, 15000, 14000, 17000, 16000, 19000];
+const expensesData = [8000, 7000, 9000, 10000, 9500, 11000];
+const profitData = labels.map((_, i) => revenueData[i] - expensesData[i]);
+
+const ctx = document.getElementById('revenueChart');
+const revenueChart = new Chart(ctx, {
+  type: 'bar',
+  data: {
+    labels: labels,
+    datasets: [
+      {
+        label: 'Revenue',
+        data: revenueData,
+        backgroundColor: 'rgba(54, 162, 235, 0.7)'
+      },
+      {
+        label: 'Expenses',
+        data: expensesData,
+        backgroundColor: 'rgba(255, 99, 132, 0.7)'
+      }
+    ]
+  },
+  options: {
+    responsive: true,
+    plugins: { title: { display: true, text: 'Monthly Revenue vs Expenses' } }
+  }
+});
+
+const profitCtx = document.getElementById('profitChart');
+const profitChart = new Chart(profitCtx, {
+  type: 'line',
+  data: {
+    labels: labels,
+    datasets: [
+      {
+        label: 'Profit',
+        data: profitData,
+        borderColor: 'rgba(75, 192, 192, 1)',
+        backgroundColor: 'rgba(75, 192, 192, 0.2)',
+        fill: true,
+        tension: 0.4
+      }
+    ]
+  },
+  options: {
+    responsive: true,
+    plugins: { title: { display: true, text: 'Monthly Profit' } }
+  }
+});
+
+document.getElementById('monthRange').addEventListener('input', (e) => {
+  const count = parseInt(e.target.value, 10);
+  revenueChart.data.labels = labels.slice(0, count);
+  revenueChart.data.datasets[0].data = revenueData.slice(0, count);
+  revenueChart.data.datasets[1].data = expensesData.slice(0, count);
+  revenueChart.update();
+
+  profitChart.data.labels = labels.slice(0, count);
+  profitChart.data.datasets[0].data = profitData.slice(0, count);
+  profitChart.update();
+});

--- a/images/green_coffee.svg
+++ b/images/green_coffee.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300">
+  <rect x="50" y="50" width="300" height="200" fill="#d2b48c" stroke="#8b4513" stroke-width="4" />
+  <ellipse cx="100" cy="100" rx="10" ry="15" fill="#228B22" />
+  <ellipse cx="140" cy="120" rx="10" ry="15" fill="#228B22" />
+  <ellipse cx="180" cy="90" rx="10" ry="15" fill="#228B22" />
+  <ellipse cx="220" cy="110" rx="10" ry="15" fill="#228B22" />
+  <ellipse cx="260" cy="95" rx="10" ry="15" fill="#228B22" />
+  <text x="140" y="30" fill="#006400" font-size="24">Green Coffee</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Financial Dashboard</title>
+  <style>
+    body { font-family: Arial, sans-serif; text-align: center; }
+    .charts { display: flex; justify-content: space-around; flex-wrap: wrap; }
+    .charts canvas { max-width: 400px; }
+    .image-container { margin: 20px; }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <h1>Financial Dashboard</h1>
+  <div class="image-container">
+    <img src="images/green_coffee.svg" alt="Green coffee in burlap bags" width="300" />
+  </div>
+  <label for="monthRange">Months to display:</label>
+  <input type="range" id="monthRange" min="1" max="6" value="6" />
+  <div class="charts">
+    <canvas id="revenueChart"></canvas>
+    <canvas id="profitChart"></canvas>
+  </div>
+  <script src="dashboard.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add HTML dashboard showing revenue, expenses, and profit charts with Chart.js
- Include adjustable month range slider and an illustration of green coffee in burlap bags
- Document usage in README

## Testing
- `node --check dashboard.js`

------
https://chatgpt.com/codex/tasks/task_e_6898a428ce4c832bab9b245cc685d209